### PR TITLE
Bugfixes for odachi recipe and wakizashi sprite

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/flail.dm
+++ b/code/game/objects/items/rogueweapons/melee/flail.dm
@@ -151,11 +151,12 @@
 	wlength = WLENGTH_NORMAL
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_HIP
+	blade_dulling = DULLING_BASHCHOP
 	associated_skill = /datum/skill/combat/whipsflails
 	smeltresult = /obj/item/ingot/iron
 	parrysound = list('sound/combat/parry/parrygen.ogg')
 	swingsound = BLUNTWOOSH_MED
-	max_blade_int = 100
+	max_blade_int = 150
 	max_integrity = 240
 	throwforce = 5
 	wdefense = 2

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -592,6 +592,7 @@
 	force = 30
 	name = "wakizashi"
 	desc = "A shorter design of katana designed to replace the tanto as a samurai's sidearm, the wakizashi most commonly accompanies an uchigatana when worn in a samurai's daisho. Even on its own, the wakizashi is popular with commoners as a defense against bandits and is often legal weapon for them to carry."
+	icon_state = "wakizashi"
 	possible_item_intents = list(/datum/intent/sword/cut/short, /datum/intent/sword/thrust/short, /datum/intent/sword/chop)
 	smeltresult = /obj/item/ingot/steel
 	minstr = 6

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -381,7 +381,7 @@
 
 /datum/anvil_recipe/weapons/greatsword/odachi
 	name = "odachi (+2 steel ingots)"
-	/obj/item/rogueweapon/greatsword/odachi
+	created_item = /obj/item/rogueweapon/greatsword/odachi
 
 /datum/anvil_recipe/weapons/steelshield
 	name = "heraldic shield (2) (+h)"


### PR DESCRIPTION
Fixes a bug where the odachi smithing recipe creates a normal greatsword instead

Fixes a bug where the wakizashi has the same sprite as a shortsword