### PR TITLE
Adds a check to remove kitsune maw when selected MMB intent isn't BITE

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -478,6 +478,17 @@
 	if(input != QINTENT_SPELL)
 		if(ranged_ability)
 			ranged_ability.deactivate()
+	var/mutable_appearance/eldritch_maw = mutable_appearance('icons/roguetown/mob/bodies/m/mt_kit.dmi', "eldritch_maw", MOUTH_LAYER)
+	var/mob/living/carbon/human/H = src
+	if(input != QINTENT_BITE)
+		if(ishuman(src) && H.dna.species.name == "Kitsune") //The intention is to take away the overlay if not clicking on bite intent.
+			for(eldritch_maw in H.overlays)
+				H.remove_overlay(eldritch_maw)
+				visible_message("<span class='warning'>[src]'s face knits together.</span>")
+				playsound(src.loc, 'sound/combat/fracture/fracturewet (2).ogg', 50, 1)
+				H.cut_overlay(eldritch_maw)
+				update_icon()
+				H.update_body()
 	switch(input)
 		if(QINTENT_KICK)
 			if(mmb_intent?.type == INTENT_KICK)
@@ -498,9 +509,7 @@
 				qdel(mmb_intent)
 				input = null
 				mmb_intent = null
-				var/mob/living/carbon/human/H = src
 				if(ishuman(src) && H.dna.species.name == "Kitsune") //The intention is to make them get an overlay. They may crit with their bite, but everyone will know they are biting.
-					var/mutable_appearance/eldritch_maw = mutable_appearance('icons/roguetown/mob/bodies/m/mt_kit.dmi', "eldritch_maw", MOUTH_LAYER)
 					H.remove_overlay(eldritch_maw)
 					visible_message("<span class='warning'>[src]'s face knits together.</span>")
 					playsound(src.loc, 'sound/combat/fracture/fracturewet (2).ogg', 50, 1)
@@ -509,9 +518,7 @@
 					H.update_body()
 			else
 				mmb_intent = new INTENT_BITE(src)
-				var/mob/living/carbon/human/H = src
 				if(ishuman(src) && H.dna.species.name == "Kitsune") //The intention is to make them get an overlay. They may crit with their bite, but everyone will know they are biting.
-					var/mutable_appearance/eldritch_maw = mutable_appearance('icons/roguetown/mob/bodies/m/mt_kit.dmi', "eldritch_maw", MOUTH_LAYER)
 					H.remove_overlay(eldritch_maw)
 					visible_message("<span class='warning'>[src]'s face splits into a deadly maw.</span>")
 					playsound(src.loc, 'sound/combat/fracture/fracturewet (2).ogg', 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- Note: PRs including balance changes authored by anyone other than maintainers and official devs will not be considered. -->

## About The Pull Request
Attempts to fix a bug where selecting a MMB intent other than bite with maw split causes the overlay to be permanently stuck.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review or prevent the PR from being merged! -->

## Why It's Good For The Game
The reason the overlay becomes unremovable is because the proc that normally removes the overlay when you click on BITE to turn it off doesn't trigger when you click on any other MMB intent. This causes a duplicate to be added the next time bite is selected, and the proc only removes one instance at a time. This prevents the overlay from duplicating by adding the missing intent check.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
