### PR TITLE
Adds randomized shirts to clerics and Fixes == Patron Line

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -47,6 +47,7 @@
 			neck = /obj/item/clothing/neck/roguetown/psicross/necra
 
 	armor = /obj/item/clothing/suit/roguetown/armor/plate
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
@@ -54,7 +55,7 @@
 	beltr = /obj/item/rogueweapon/mace
 	beltl = /obj/item/storage/belt/rogue/pouch
 	backr = /obj/item/rogueweapon/shovel
-	if(H.PATRON == /datum/patrongods/necra)
+	if(H.PATRON != /datum/patrongods/necra)
 		cloak = /obj/item/clothing/cloak/raincloak/mortus
 	if(H.mind)
 		H.mind.adjust_skillrank(/datum/skill/combat/axesmaces, 4, TRUE)


### PR DESCRIPTION
Adds randomized shirts to basegame clerics so they no longer feel cold and shirtless without their chestplate

Fixes the code that assigns a cloak to Necra clerics so they actually work, was == now != from observations of similar code.

